### PR TITLE
ci: k8s version bump 1.2x -> 1.24

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.22/stable
+          channel: 1.24/stable
           charmcraft-channel: latest/candidate
           # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
           #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in


### PR DESCRIPTION
[skip ci] ci: k8s version bump 1.2x -> 1.24