### PR TITLE
feat: bump image version to v2.2.0

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from certs import gen_certs
 
 K8S_RESOURCE_FILES = ["src/templates/webhook_resources.yaml"]
-TAGGED_IMAGE = "charmedkubeflow/namespace-node-affinity:90dde45ab265af91369d09a377a26034bc453a5d"
+TAGGED_IMAGE = "charmedkubeflow/namespace-node-affinity:v2.2.0"
 
 
 class NamespaceNodeAffinityOperator(CharmBase):

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from certs import gen_certs
 
 K8S_RESOURCE_FILES = ["src/templates/webhook_resources.yaml"]
-TAGGED_IMAGE = "charmedkubeflow/namespace-node-affinity:v2.2.0"
+TAGGED_IMAGE = "charmedkubeflow/namespace-node-affinity:2.2.0"
 
 
 class NamespaceNodeAffinityOperator(CharmBase):


### PR DESCRIPTION
Previously, we used a locally built image that patched some bugs in the upstream release.  This updated image is now based on upstream after our bug fixes were merged.  This should have no functional change on the charm's operation.