### PR TITLE
fix: Remove k8s resources on charm removal

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -157,15 +157,12 @@ async def test_webhook_workload(ops_test: OpsTest, temp_pod_deleter):
 async def test_charm_removal(ops_test: OpsTest):
     """Test that the  charm can be removed without errors and leaves no leftovers."""
     await ops_test.model.remove_application(APP_NAME, block_until_done=True)
-    deleted = True
     lightkube_client = Client()
     pods = lightkube_client.list(
         Pod, namespace=ops_test.model.name, labels={"app": "namespace-node-affinity-pod-webhook"}
     )
-    for pod in pods:
-        # if there is a pod in the list, then the pod hasn't been deleted
-        deleted = False
-    assert deleted, (
+    pods_list = list(pods)
+    assert len(pods_list) == 0, (
         "Workload pod with label 'app': 'namespace-node-affinity-pod-webhook'"
         "still present on the cluster."
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -152,3 +152,20 @@ async def test_webhook_workload(ops_test: OpsTest, temp_pod_deleter):
         test_pod, name=test_pod.metadata.name, namespace=ops_test.model.name
     )
     assert test_pod_created.spec.affinity is not None
+
+
+async def test_charm_removal(ops_test: OpsTest):
+    """Test that the  charm can be removed without errors and leaves no leftovers."""
+    await ops_test.model.remove_application(APP_NAME, block_until_done=True)
+    deleted = True
+    lightkube_client = Client()
+    pods = lightkube_client.list(
+        Pod, namespace=ops_test.model.name, labels={"app": "namespace-node-affinity-pod-webhook"}
+    )
+    for pod in pods:
+        # if there is a pod in the list, then the pod hasn't been deleted
+        deleted = False
+    assert deleted, (
+        "Workload pod with label 'app': 'namespace-node-affinity-pod-webhook'"
+        "still present on the cluster."
+    )

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -7,6 +7,11 @@ from base64 import b64encode
 
 import pytest
 import yaml
+from charmed_kubeflow_chisme.kubernetes import create_charm_default_labels
+from lightkube.resources.admissionregistration_v1 import MutatingWebhookConfiguration
+from lightkube.resources.apps_v1 import Deployment
+from lightkube.resources.core_v1 import ConfigMap, Secret, Service, ServiceAccount
+from lightkube.resources.rbac_authorization_v1 import Role, RoleBinding
 from ops.model import WaitingStatus
 from ops.testing import Harness
 
@@ -101,6 +106,21 @@ class TestCharm:
             template_files=k8s_resource_files,
             context=context,
             logger=logger,
+            labels=create_charm_default_labels(
+                harness.model.app.name,
+                harness.model.name,
+                scope="auths-deploy-configmaps-sa-secrets-svc-webhooks",
+            ),
+            resource_types={
+                MutatingWebhookConfiguration,
+                Deployment,
+                Role,
+                RoleBinding,
+                Service,
+                ServiceAccount,
+                Secret,
+                ConfigMap,
+            },
         )
         mocked_load_in_cluster_generic_resources.assert_called_once_with("lightkube_client")
 


### PR DESCRIPTION
Add `remove_event` handler that removes all k8s resources created by the charm.

Closes #34