### PR TITLE
draft: PoC for refactor CI epic

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,12 +51,28 @@ jobs:
       - name: Run unit tests
         run: tox -e unit
 
-  deploy:
+  build:
+    name: Build charm
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
+    with:
+      cache: true
+
+  integration-tests:
     name: Integration Test
     runs-on: ubuntu-20.04
+    needs: [build]
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Download packed charm(s)
+        id: download-charms
+        timeout-minutes: 5
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,6 +56,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
       cache: true
+      charmcraft-snap-channel: latest/edge
 
   integration-tests:
     name: Integration Test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,7 +56,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
       cache: true
-      charmcraft-snap-channel: latest/edge
+      charmcraft-snap-channel: 2.x/edge
 
   integration-tests:
     name: Integration Test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run test
         run: |
-          sg snap_microk8s -c "tox -e integration -- --model testing"
+          sg snap_microk8s -c "tox -vve integration-using-packed-charms -- --model testing"
 
       - name: Get all
         run: kubectl get all -A

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,7 +56,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
       cache: true
-      charmcraft-snap-channel: 2.x/edge
+      charmcraft-snap-channel: 3.x/edge
 
   integration-tests:
     name: Integration Test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -3,11 +3,6 @@ name: CI
 
 on:
   workflow_call:
-    inputs:
-      build-using-cache:
-        description: Boolean that defines if charms are built using cache.
-        type: boolean
-        required: true
     secrets:
       charmcraft-credentials:
         required: true
@@ -64,7 +59,7 @@ jobs:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
-      cache: ${{ inputs.build-using-cache }}
+      cache: ${{ github.event_name == 'pull_request' }}
       charmcraft-snap-channel: 2.x/edge
 
   integration-tests:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,7 +56,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
       cache: true
-      charmcraft-snap-channel: 3.x/edge
+      charmcraft-snap-channel: 2.x/edge
 
   integration-tests:
     name: Integration Test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -3,9 +3,18 @@ name: CI
 
 on:
   workflow_call:
+    inputs:
+      build-using-cache:
+        description: Boolean that defines if charms are built using cache.
+        type: boolean
+        required: true
     secrets:
       charmcraft-credentials:
         required: true
+    outputs:
+      artifact-prefix:
+        description: "Charm packages are uploaded to GitHub artifacts beginning with this prefix."
+        value:  ${{ jobs.build.outputs.artifact-prefix }}
 
 jobs:
 
@@ -55,7 +64,7 @@ jobs:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
-      cache: true
+      cache: ${{ inputs.build-using-cache }}
       charmcraft-snap-channel: 2.x/edge
 
   integration-tests:

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,7 +60,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v21.0.0
     with:
       cache: ${{ github.event_name == 'pull_request' }}
-      charmcraft-snap-channel: 2.x/edge
+      charmcraft-snap-channel: 3.x/edge
 
   integration-tests:
     name: Integration Test

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,8 +14,6 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
-    with:
-      build-using-cache: true
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -14,10 +14,15 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+    with:
+      build-using-cache: true
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
+    needs: tests
     uses: ./.github/workflows/publish.yaml
     secrets:
       CHARMCRAFT_CREDENTIALS: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+    with:
+      artifact-prefix: ${{ needs.tests.outputs.artifact-prefix }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -21,6 +21,8 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+    with:
+      build-using-cache: false
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:
@@ -29,3 +31,5 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     secrets:
       CHARMCRAFT_CREDENTIALS: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
+    with:
+      artifact-prefix: ${{ needs.tests.outputs.artifact-prefix }}

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -21,8 +21,6 @@ jobs:
     uses: ./.github/workflows/integrate.yaml
     secrets:
       charmcraft-credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
-    with:
-      build-using-cache: false
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,10 @@ on:
         default: ''
         required: false
         type: string
+      artifact-prefix:
+        description: Built charms artifact prefix
+        required: true
+        type: string
     secrets:
       CHARMCRAFT_CREDENTIALS:
         required: true
@@ -83,12 +87,21 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
+      - name: Download packed charm(s)
+        id: download-charms
+        timeout-minutes: 5
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ inputs.artifact-prefix }}-*
+          merge-multiple: true
+
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           charm-path: ${{ matrix.charm-path }}
+          built-charm-path: ${{ steps.download-charms.outputs.download-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
           charmcraft-channel: latest/candidate

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,14 +45,17 @@ jobs:
         run: bash .github/workflows/get-charm-paths.sh
 
 
-  publish-charm:
-    name: Publish Charm
+  define-channel:
+    name: Define destination channel
     runs-on: ubuntu-20.04
     needs: get-charm-paths
     strategy:
       fail-fast: false
       matrix:
         charm-path: ${{ fromJson(needs.get-charm-paths.outputs.charm_paths_list) }}
+    outputs:
+      destination-channel: ${{ steps.parse-inputs.outputs.destination_channel }}
+      tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
 
     steps:
       - name: Checkout
@@ -95,13 +98,14 @@ jobs:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
 
-      - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.6.2
-        with:
-          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          charm-path: ${{ matrix.charm-path }}
-          built-charm-path: ${{ steps.download-charms.outputs.download-path }}
-          channel: ${{ steps.parse-inputs.outputs.destination_channel }}
-          tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+  release:
+    name: Release charm
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v21.0.0
+    needs: [define-channel]
+    with:
+      channel: ${{ needs.define-channel.outputs.destination-channel }}
+      artifact-prefix: ${{ inputs.artifact-prefix }}
+    secrets:
+      charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    permissions:
+      contents: write  # Needed to create GitHub release

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,14 +90,6 @@ jobs:
           echo "setting output of tag_prefix=$tag_prefix"
           echo "::set-output name=tag_prefix::$tag_prefix"
 
-      - name: Download packed charm(s)
-        id: download-charms
-        timeout-minutes: 5
-        uses: actions/download-artifact@v4
-        with:
-          pattern: ${{ inputs.artifact-prefix }}-*
-          merge-multiple: true
-
   release:
     name: Release charm
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v21.0.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -105,6 +105,7 @@ jobs:
     with:
       channel: ${{ needs.define-channel.outputs.destination-channel }}
       artifact-prefix: ${{ inputs.artifact-prefix }}
+      create-github-release: ${{ github.event_name == 'push' }}
     secrets:
       charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.charm
+*__pycache__
+*.tox
+venv/

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,4 +10,4 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]  # Fixes install of some packages
+    charm-python-packages: []

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,11 +5,11 @@
 """Integration tests for Namespace Node Affinity Operator/Charm."""
 
 import logging
+import os
 from pathlib import Path
 from time import sleep
 
 import pytest
-import os
 import yaml
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
@@ -40,14 +40,17 @@ SETTINGS_YAML_TEMPLATE = """
           - the-testing-val2
         """
 
+
 @pytest.fixture
 def use_packed_charms() -> str:
-    return os.environ.get("USE_PACKED_CHARMS", "false").replace("\"", "")
+    """Return environment variable `USE_PACKED_CHARMS`. If it's not found, return `false`."""
+    return os.environ.get("USE_PACKED_CHARMS", "false").replace('"', "")
+
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, use_packed_charms):
     """Build and deploy the charm, asserting on the unit status."""
-    charm_path="."
+    charm_path = "."
     if use_packed_charms.lower() == "true":
         charm_under_test = await get_packed_charms(charm_path)
     else:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,0 +1,42 @@
+import os
+import pathlib
+import subprocess
+import typing
+
+import yaml
+
+async def get_packed_charms(
+    charm_path: typing.Union[str, os.PathLike], bases_index: int = None
+) -> pathlib.Path:
+    """
+    Simplified version of https://github.com/canonical/data-platform-workflows/blob/06f252ea079edfd055cee236ede28c237467f9b0/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/_plugin.py#L22
+    """
+    charm_path = pathlib.Path(charm_path)
+    # namespace-node-affinity_ubuntu-20.04-amd64.charm
+    # <metadata-name>_<base>-<architecture>.charm
+    architecture = subprocess.run(
+        ["dpkg", "--print-architecture"],
+        capture_output=True,
+        check=True,
+        encoding="utf-8",
+    ).stdout.strip()
+    assert architecture in ("amd64", "arm64")
+    packed_charms = list(charm_path.glob(f"*-{architecture}.charm"))
+    if len(packed_charms) == 1:
+        # python-libjuju's model.deploy(), juju deploy, and juju bundle files expect local charms
+        # to begin with `./` or `/` to distinguish them from Charmhub charms.
+        # Therefore, we need to return an absolute path—a relative `pathlib.Path` does not start
+        # with `./` when cast to a str.
+        # (python-libjuju model.deploy() expects a str but will cast any input to a str as a
+        # workaround for pytest-operator's non-compliant `build_charm` return type of
+        # `pathlib.Path`.)
+        return packed_charms[0].resolve(strict=True)
+    elif len(packed_charms) > 1:
+        message = f"More than one matching .charm file found at {charm_path=} for {architecture=}: {packed_charms}."
+        if bases_index is None:
+            message += " Specify `bases_index`"
+        raise ValueError(message)
+    else:
+        raise ValueError(
+            f"Unable to find .charm file for {architecture=} and {bases_index=} at {charm_path=}"
+        )

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -1,16 +1,17 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Utils functions for integration tests. Should be moved to chisme."""
+
 import os
 import pathlib
 import subprocess
 import typing
 
-import yaml
 
 async def get_packed_charms(
     charm_path: typing.Union[str, os.PathLike], bases_index: int = None
 ) -> pathlib.Path:
-    """
-    Simplified version of https://github.com/canonical/data-platform-workflows/blob/06f252ea079edfd055cee236ede28c237467f9b0/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/_plugin.py#L22
-    """
+    """Simplified version of https://github.com/canonical/data-platform-workflows/blob/06f252ea079edfd055cee236ede28c237467f9b0/python/pytest_plugins/pytest_operator_cache/pytest_operator_cache/_plugin.py#L22."""  # noqa: E501
     charm_path = pathlib.Path(charm_path)
     # namespace-node-affinity_ubuntu-20.04-amd64.charm
     # <metadata-name>_<base>-<architecture>.charm
@@ -32,7 +33,7 @@ async def get_packed_charms(
         # `pathlib.Path`.)
         return packed_charms[0].resolve(strict=True)
     elif len(packed_charms) > 1:
-        message = f"More than one matching .charm file found at {charm_path=} for {architecture=}: {packed_charms}."
+        message = f"More than one matching .charm file found at {charm_path=} for {architecture=}: {packed_charms}."  # noqa: E501
         if bases_index is None:
             message += " Specify `bases_index`"
         raise ValueError(message)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ max-line-length = 100
 [tox]
 skipsdist = True
 skip_missing_interpreters = True
-envlist = update-requirements, fmt, lint, unit, integration
+envlist = update-requirements, fmt, lint, unit, integration{-using-packed-charms,}
 
 [vars]
 all_path = {[vars]src_path} {[vars]tst_path}
@@ -73,8 +73,10 @@ deps =
     -r requirements-unit.txt
 description = Run unit tests
 
-[testenv:integration]
+[testenv:integration{-using-packed-charms,}]
 commands = pytest -v --tb native --asyncio-mode=auto {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
+setenv = 
+    using-packed-charms: USE_PACKED_CHARMS = "true"
 deps =
     -r requirements-integration.txt
 description = Run integration tests


### PR DESCRIPTION
PoC for refactor CI epic. This aims to implement the following:
1. Build in separate GH runner and publish artifact
	1. Download and use in tests
	2. Download and use in publish job
2. Use cache for building (on pull request only)

##### Results
Building time went [from 15 minutes](https://github.com/canonical/namespace-node-affinity-operator/actions/runs/10883494776/job/30196791134#step:12:7) (using latest/edge didn't have the hotfix for `charmcraftcache` to work) to [2 minutes](https://github.com/canonical/namespace-node-affinity-operator/actions/runs/10885254242/job/30202435843?pr=47#step:12:7) (using charmcraft `2.x/edge`).

##### Implementation notes
* Uses charmcraft 2.x/edge due to canonical/charmcraft##1456. Note that `3.x/edge` didn't work but probably has to do with charmcraftcache or the absence of strict dependencies.
* Removes `charm-python-packages` but need to use also `charm-strict-dependencies`.


Ref https://github.com/canonical/bundle-kubeflow/issues/1070