### PR TITLE
ci: update the integrate job to match the latest supported versions of microk8s and juju

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -61,16 +61,9 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.24/stable
+          channel: 1.29-strict/stable
           charmcraft-channel: latest/candidate
-          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
-          #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in
-          #       the "metrics-endpoint-relation-changed" hook.
-          bootstrap-options: --agent-version="2.9.34"
-      # TODO: Remove once the actions-operator does this automatically
-      - name: Configure kubectl
-        run: |
-          sg microk8s -c "microk8s config > ~/.kube/config"
+          juju-channel: 3.4/stable
 
       - name: Run test
         run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run test
         run: |
-          sg microk8s -c "tox -e integration -- --model testing"
+          sg snap_microk8s -c "tox -e integration -- --model testing"
 
       - name: Get all
         run: kubectl get all -A

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -44,7 +44,7 @@ idna==3.4
     #   rfc3986
 iniconfig==1.1.1
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   -r ./requirements.txt
     #   charmed-kubeflow-chisme

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,7 @@ ops==1.5.4
     #   charmed-kubeflow-chisme
 ordered-set==4.1.0
     # via deepdiff
-pyyaml==6.0
+pyyaml==6.0.2
     # via
     #   lightkube
     #   ops

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,11 @@ httpx==0.23.1
 idna==3.4
     # via
     #   anyio
-    #   rfc3986
-jinja2==3.1.2
+    #   httpx
+    #   requests
+importlib-resources==6.0.1
+    # via jsonschema
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 lightkube==0.11.0
     # via


### PR DESCRIPTION
This commit brings the required changes to make the CI work:

* build: bump jinja2 3.1.x -> 3.1.4 (#42)
* ci: update the integrate job to match the latest supported versions of microk8s and juju
* ci: change microk8s name to sg_microk8s after being updated