### PR TITLE
refactor, chore: move TAGGED_IMAGE away from charm code, add tools/get-images.sh

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,9 @@
 options:
+  namespace-node-affinity-image:
+    type: string
+    default: 'charmedkubeflow/namespace-node-affinity:2.2.0'
+    description: |
+      Container image to be used by the namespace-node-affinity workload.
   settings_yaml:
     type: string
     default: ''

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,8 +21,6 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from certs import gen_certs
 
 K8S_RESOURCE_FILES = ["src/templates/webhook_resources.yaml"]
-TAGGED_IMAGE = "charmedkubeflow/namespace-node-affinity:2.2.0"
-
 
 class NamespaceNodeAffinityOperator(CharmBase):
     """A Juju Charm for Namespace Node Affinity."""
@@ -123,7 +121,7 @@ class NamespaceNodeAffinityOperator(CharmBase):
         return {
             "app_name": self._name,
             "namespace": self._namespace,
-            "image": TAGGED_IMAGE,
+            "image": self.config["namespace-node-affinity-image"],
             "ca_bundle": b64encode(self._cert_ca.encode("ascii")).decode("utf-8"),
             "cert": b64encode(self._cert.encode("ascii")).decode("utf-8"),
             "cert_key": b64encode(self._cert_key.encode("ascii")).decode("utf-8"),

--- a/src/charm.py
+++ b/src/charm.py
@@ -22,6 +22,7 @@ from certs import gen_certs
 
 K8S_RESOURCE_FILES = ["src/templates/webhook_resources.yaml"]
 
+
 class NamespaceNodeAffinityOperator(CharmBase):
     """A Juju Charm for Namespace Node Affinity."""
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -10,7 +10,7 @@ import yaml
 from ops.model import WaitingStatus
 from ops.testing import Harness
 
-from charm import K8S_RESOURCE_FILES, TAGGED_IMAGE, NamespaceNodeAffinityOperator
+from charm import K8S_RESOURCE_FILES, NamespaceNodeAffinityOperator
 
 # Used for test_get_settings_yaml
 SETTINGS_YAML = """
@@ -48,7 +48,7 @@ class TestCharm:
     def test_context(self, harness: Harness):
         """Test context property."""
         model_name = "test-model"
-        image = TAGGED_IMAGE
+        image = harness.model.config["namespace-node-affinity-image"]
         ca_bundle = "bundle123"
         cert = "cert123"
         cert_key = "cert_key123"

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+
+set -xe
+
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name config.yaml -exec yq '.options | with_entries(select(.key | test("-image$"))) | .[].default' {} \; | tr -d '"'))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
This PR introduces the following changes:

* chore: add tools/get-images.sh to gather images from this charm

This commit adds the support script for gathering the images this charm uses.
Part of canonical/bundle-kubeflow#1084

* refactor: move TAGGED_IMAGE from charm code to config.yaml

This commit removes the TAGGED_IMAGE variable from the charm code and places the image to be used as a configuration option for the charm.